### PR TITLE
Use fairing to deploy the model using Seldon and send predictions from a notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 !.gitignore
 !.dockerignore
 **/flask_session
+build/**
+fairing/__pycache__/**

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# IMG is the base path for images..
+# Individual images will be
+# $(IMG)/$(NAME):$(TAG)
+IMG ?= gcr.io/code-search-demo/mlapp/base
+PROJECT ?= code-search-demo
+
+# List any changed  files. We only include files in the notebooks directory.
+# because that is the code in the docker image.
+# In particular we exclude changes to the ksonnet configs.
+CHANGED_FILES := $(shell git diff-files)
+
+# Whether to use cached images with GCB
+USE_IMAGE_CACHE ?= true
+
+ifeq ($(strip $(CHANGED_FILES)),)
+# Changed files is empty; not dirty
+# Don't include --dirty because it could be dirty if files outside the ones we care
+# about changed.
+GIT_VERSION := $(shell git describe --always)
+else
+GIT_VERSION := $(shell git describe --always)-dirty-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
+TAG := $(shell date +v%Y%m%d)-$(GIT_VERSION)
+all: build
+
+# To build without the cache set the environment variable
+# export DOCKER_BUILD_OPTS=--no-cache
+.PHONY: build
+build-dir: ./deployment/Dockerfile ./requirements.txt ./flask_app
+	rm -rf ./build
+	mkdir  -p build
+	cp ./requirements.txt ./build
+	cp ./deployment/Dockerfile ./build
+	cp -r ./flask_app ./build
+
+build: build-dir
+	cd build && docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) -f Dockerfile . \
+           --label=git-verions=$(GIT_VERSION)
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	@echo Built $(IMG):latest
+	@echo Built $(IMG):$(TAG)
+
+
+build-gcb: build-dir	
+	gcloud builds submit --machine-type=n1-highcpu-32 --project=$(PROJECT) --tag=$(IMG):$(TAG) \
+		--timeout=3600 ./build
+	@echo Built $(IMG):$(TAG)
+
+# Build but don't attach the latest tag. This allows manual testing/inspection of the image
+# first.
+push: build
+	docker -- push $(IMG):$(TAG)
+	@echo Pushed $(IMG):$(TAG)

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -64,7 +64,8 @@ RUN pip install \
     pandas==0.24.2 \
     pyarrow==0.12.1 \
     scikit-learn==0.20.3 \
-    tensorflow==1.12.0
+    tensorflow==1.12.0 \
+    seldon-core==0.2.6
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/fairing/LabelPrediction.py
+++ b/fairing/LabelPrediction.py
@@ -1,0 +1,53 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Use Append builder and deploy the model.
+
+The file needs to be named the same as the class containing the predict method.
+This is how Seldon works.
+https://docs.seldon.io/projects/seldon-core/en/latest/python/python_wrapping.html
+
+This is the Seldon interface class.
+"""
+
+import app
+import logging
+import tensorflow as tf
+
+class LabelPrediction(object):
+  def __init__(self):
+    """"""
+    self.graph = None
+    self.issue_labeler = None
+
+  def predict(self, X, feature_names):
+    """Predict using the model for given ndarray."""
+
+    if self.issue_labeler is None:
+      # Load the model.
+      logging.info("Creating the issue labeler and initializing TF graph.")
+      self.graph = tf.get_default_graph()
+      self.issue_labeler = app.init_issue_labeler()
+
+    probabilities = self.issue_labeler.get_probabilities(body=X[1],
+                                                    title=X[0])
+
+    logging.info("Probability keys: %s", probabilities.keys())
+
+    p = [0] * 3
+    for i, k in enumerate(["bug", "feature_request", "question"]):
+      if not k in probabilities:
+        continue
+      p[i] = probabilities[k]
+
+    return [p]

--- a/fairing/README.md
+++ b/fairing/README.md
@@ -1,0 +1,85 @@
+# Fairing and MLApp
+
+We will use fairing and Seldon to deploy our model on Kubeflow.
+
+[fairing](https://github.com/kubeflow/fairing/tree/master/fairing) is a python
+SDK that makes it super easy to 
+
+  * Build Docker images from notebooks and python files
+  * Create Kubernetes deployments and services to deploy your model.
+
+[Seldon](https://github.com/SeldonIO/seldon-core) provides a platform for deploying
+models on Kubernetes.
+
+fairing uses seldon to wrap your python functions in a model server that can handle
+REST or gRPC calls.
+
+Below are instructions for deploying your model using fairing.
+
+Fairing is a python library so it can be used in notebooks or from python modules
+invoked via the python interpreter.
+
+This example will use notebooks running inside your Kubeflow cluster but 
+you could just as easily run fairing in your favorite IDE on your local 
+machine and still deploy on your Kubeflow cluster.
+
+
+## Create a base image
+
+We need to create a suitable Docker image to use as our base image.
+
+We will run this step on your local machine using Docker.
+
+We could also use Kaniko and the ClusterBuilder inside fairing to run this
+inside your Kubeflow cluster.
+
+We could build a complete Docker image every time our code changes but this
+would be rather slow since installing dependencies like pandas can be expensive.
+
+So instead we build a base Docker image which contains our dependencies and
+then just create a new image by adding our code to this image.
+
+Run the following command to build and push your image
+
+```
+IMG=<Registry URI for the image>
+IMG=${IMG} make push
+```
+
+Set IMG to URI you want to host the image in your docker registry.
+
+On Google Cloud Platform we can use GCR and set the URI to
+
+```
+IMG=gcr.io/${PROJECT}/mlapp/base
+```
+
+  * Substitute your GCP project id for PROJECT
+
+On GCP you may need to run the following gcloud command to provide docker with credentials for your GCP project
+
+```
+gcloud auth configure docker
+```
+
+You can also use GCB to build the image. This can be much faster because we avoid pulling/pushing the base image over our local network which can be quite large
+
+```
+PROJECT=${PROJECT} IMG=${IMG} make build-gcb
+```
+
+## Start a notebook on Kubeflow
+
+If you have not already done so, follow the Kubeflow getting [started guide](https://www.kubeflow.org/docs/started/) to deploy Kubeflow.
+
+Then follow the Kubeflow [instructions](https://www.kubeflow.org/docs/components/jupyter/) to spawn a Jupyter notebook.
+
+Once you've started Jupyter, start a shell and clone the repo.
+
+```
+git clone https://github.com/hamelsmu/MLapp.git git_mlapp
+```
+
+Then open the notebook fairing /label-prediction-fairing.ipynb
+
+Then follow along in the notebook.

--- a/fairing/deploy_with_fairing.py
+++ b/fairing/deploy_with_fairing.py
@@ -1,0 +1,66 @@
+import argparse
+import logging
+import fairing
+from fairing.builders.append import append
+import fnmatch
+import numpy as np
+import os
+import shutil
+import tempfile
+
+def deploy(registry, base_image):
+  logging.getLogger().setLevel(logging.INFO)
+  fairing.config.set_builder('append', registry=registry, base_image=base_image)
+
+  # Add a common label.
+  labels = {
+    "app": "mlapp",
+  }
+  fairing.config.set_deployer('serving', serving_class="LabelPrediction",
+                              labels=labels)
+
+  # Get the list of all the python files
+  this_dir = os.path.dirname(__file__)
+  base_dir = os.path.abspath(os.path.join(this_dir, ".."))
+  flask_dir = os.path.join(base_dir, "flask_app")
+  input_files = []
+
+  # Context gymnastics.
+  # Create a directory with the desired layout for app.
+  # We need to flatten things because Seldon expects the interface module
+  # to be a top level module.
+  #
+  # TODO(https://github.com/SeldonIO/seldon-core/issues/465): Seldon
+  # can't handle the module being nested; it needs to be top level module.
+
+  context_dir = tempfile.mkdtemp()
+
+  logging.info("Using context dir %s", context_dir)
+
+  for dir_to_copy in [flask_dir, this_dir]:
+    for root, dirs, files in os.walk(dir_to_copy, topdown=False):
+      for name in files:
+        if not fnmatch.fnmatch(name, "*.py"):
+          continue
+        shutil.copyfile(os.path.join(root, name),
+                        os.path.join(context_dir, name))
+        input_files.append(name)
+
+  # Need to change to context_dir so that paths are added at the correct
+  # location in the context .tar.gz
+  os.chdir(context_dir)
+  fairing.config.set_preprocessor('python', input_files=input_files)
+  fairing.config.run()
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "--registry", default="", type=str,
+    help=("The registry where your images should be pushed"))
+
+  parser.add_argument(
+    "--base_image", default="", type=str,
+    help=("The base image to use"))
+
+  args = parser.parse_args()
+  deploy(args.registry, args.base_image)

--- a/fairing/label-prediction-fairing.ipynb
+++ b/fairing/label-prediction-fairing.ipynb
@@ -1,0 +1,247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train and deploy on Google Cloud Platform (GCP)\n",
+    "\n",
+    "This notebook introduces you to using Kubeflow Fairing to train and deploy a model to Kubeflow on Google Kubernetes Engine (GKE), and Google Cloud ML Engine. This notebook demonstrate how to:\n",
+    " \n",
+    "* Train an XGBoost model in a local notebook,\n",
+    "* Use Kubeflow Fairing to train an XGBoost model remotely on Kubeflow,\n",
+    "* Use Kubeflow Fairing to train an XGBoost model remotely on Cloud ML Engine,\n",
+    "* Use Kubeflow Fairing to deploy a trained model to Kubeflow, and\n",
+    "* Call the deployed endpoint for predictions.\n",
+    "\n",
+    "To learn more about how to run this notebook locally, see the guide to [training and deploying on GCP from a local notebook][gcp-local-notebook].\n",
+    "\n",
+    "[gcp-local-notebook]: https://kubeflow.org/docs/fairing/gcp-local-notebook/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import logging\n",
+    "import sys\n",
+    "logging.basicConfig(format='%(message)s')\n",
+    "logging.getLogger().setLevel(logging.INFO)\n",
+    "\n",
+    "# HACK DO NOT SUBMIT\n",
+    "# This is just to pick up some commits I made to improve logging\n",
+    "sys.path = [\"/home/jovyan/git_kubeflow-fairing\"] + sys.path\n",
+    "\n",
+    "import fairing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "PROJECT=code-search-demo\n",
+      "DOCKER_REGISTRY=gcr.io/code-search-demo/fairing-job\n",
+      "BASE_IMAGE=gcr.io/code-search-demo/mlapp/base:v20190410-ea12733-dirty-23b869\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Setting up google container repositories (GCR) for storing output containers\n",
+    "# You can use any docker container registry istead of GCR\n",
+    "GCP_PROJECT = fairing.cloud.gcp.guess_project_name()\n",
+    "DOCKER_REGISTRY = 'gcr.io/{}/fairing-job'.format(GCP_PROJECT)\n",
+    "BASE_IMAGE = \"gcr.io/code-search-demo/mlapp/base:v20190410-ea12733-dirty-23b869\"\n",
+    "\n",
+    "logging.info(\"PROJECT=%s\", GCP_PROJECT)\n",
+    "logging.info(\"DOCKER_REGISTRY=%s\", DOCKER_REGISTRY)\n",
+    "logging.info(\"BASE_IMAGE=%s\", BASE_IMAGE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy on Kubeflow\n",
+    "\n",
+    "Import the `fairing` library and configure the GCP environment that your training or prediction job will run in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using context dir /tmp/tmp4glxr2is\n",
+      "Using preprocessor: <fairing.preprocessors.base.BasePreProcessor object at 0x7f1cd3b86f98>\n",
+      "Using builder: <fairing.builders.append.append.AppendBuilder object at 0x7f1cd3b86128>\n",
+      "Building image...\n",
+      "Creating docker context: /tmp/fairing.context.tar.gz\n",
+      "Adding files to context: {'sql_models.py', 'mlapp.py', 'LabelPrediction.py', 'utils.py', 'deploy_with_fairing.py', 'app.py'}\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding /home/jovyan/git_kubeflow-fairing/fairing/__init__.py at /app/fairing/__init__.py\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding /home/jovyan/git_kubeflow-fairing/fairing/runtime_config.py at /app/fairing/runtime_config.py\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding sql_models.py at /app/sql_models.py\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding mlapp.py at /app/mlapp.py\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding LabelPrediction.py at /app/LabelPrediction.py\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding utils.py at /app/utils.py\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding deploy_with_fairing.py at /app/deploy_with_fairing.py\n",
+      "Context: /tmp/fairing.context.tar.gz, Adding app.py at /app/app.py\n",
+      "Loading Docker credentials for repository 'gcr.io/code-search-demo/mlapp/base:v20190410-ea12733-dirty-23b869'\n",
+      "Invoking 'docker-credential-gcloud' to obtain Docker credentials.\n",
+      "Successfully obtained Docker credentials.\n",
+      "Image successfully built in 0.6910101249959553s.\n",
+      "Pushing image gcr.io/code-search-demo/fairing-job/fairing-job:7F685A32...\n",
+      "Loading Docker credentials for repository 'gcr.io/code-search-demo/fairing-job/fairing-job:7F685A32'\n",
+      "Invoking 'docker-credential-gcloud' to obtain Docker credentials.\n",
+      "Successfully obtained Docker credentials.\n",
+      "Uploading gcr.io/code-search-demo/fairing-job/fairing-job:7F685A32\n",
+      "Layer sha256:579615b53f1c545a0ee0d8b548ba0a29cb7233b65cf4389bc4fde62cb722a61d exists, skipping\n",
+      "Layer sha256:27833a3ba0a545deda33bb01eaf95a14d05d43bf30bce9267d92d17f069fe897 exists, skipping\n",
+      "Layer sha256:52bac8a245e2534014ed3e051a4ff9189405e0c65de22abd8e6177fe557a943d exists, skipping\n",
+      "Layer sha256:abc60a40f32fc717ad4dc3e17cb371e640ea8065f5d7eb91c78ff68960914206 exists, skipping\n",
+      "Layer sha256:ad5023f26108a6aa2e12a06aea7195cb4ff6c38bfd27e54f3a03cb8694958531 exists, skipping\n",
+      "Layer sha256:7c76daa9be075c4128f298c2b5f1db591276083c076de49c545b4eeec8f557b1 exists, skipping\n",
+      "Layer sha256:79cd8786cff153b07b9649946fc90cc41f18eb84c99425ba1aa0d8bcd1b4f174 exists, skipping\n",
+      "Layer sha256:e8b088aea3d5f721ab4db06b4e91a8ea63a70e9c45cfe501f123e4d3650084c0 exists, skipping\n",
+      "Layer sha256:b7a013bcc41ce54c53820ccb09228e36d8bac14ab1b13cece1d69ee480a4fed8 exists, skipping\n",
+      "Layer sha256:e0201e3501e8fdc678f22ad64699b694fd2c9618a6c7d1e2c6ed91c9a65b1b0b exists, skipping\n",
+      "Layer sha256:bee9b272bde4503fdfd257c01c263aa879f49727c86b6658aa35205c303185f0 exists, skipping\n",
+      "Layer sha256:44d8df5f32379d10e987332afa04ad732db1f105775050a5cf20fde9ef6bc4ad exists, skipping\n",
+      "Layer sha256:dddf6b0be585fcff6655fd9c9a91160283b9d7e38871e9da6dc05ae1712e88ac exists, skipping\n",
+      "Layer sha256:f1cec6ebcb282d0c2fffd07fb6246616615d4bde85ffa1412cadbd6675800eca pushed.\n",
+      "Layer sha256:9907e0eba23408f2b256699577e4ff0fd29959eff8e749ce455356ed99e0635c pushed.\n",
+      "Finished upload of: gcr.io/code-search-demo/fairing-job/fairing-job:7F685A32\n",
+      "Pushed image gcr.io/code-search-demo/fairing-job/fairing-job:7F685A32 in 2.9041167849936755s.\n",
+      "Deployment fairing-deployer-wf99x launched.\n",
+      "In cluster Endpoint http://fairing-service-hg7gx.kubeflow.svc.cluster.local launched.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for prediction endpoint to come up...\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-11-d7ecd2125dee>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mdeploy_with_fairing\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mimportlib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdeploy_with_fairing\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mdeploy_with_fairing\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdeploy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mDOCKER_REGISTRY\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mBASE_IMAGE\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/tmp/tmpbrbxqv3f/deploy_with_fairing.py\u001b[0m in \u001b[0;36mdeploy\u001b[0;34m(registry, base_image)\u001b[0m\n\u001b[1;32m     51\u001b[0m   \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcontext_dir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     52\u001b[0m   \u001b[0mfairing\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconfig\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_preprocessor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'python'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minput_files\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0minput_files\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 53\u001b[0;31m   \u001b[0mfairing\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconfig\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     54\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     55\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0m__name__\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'__main__'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/git_kubeflow-fairing/fairing/config.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    104\u001b[0m         \u001b[0mbuilder\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbuild\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    105\u001b[0m         \u001b[0mpod_spec\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbuilder\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgenerate_pod_spec\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 106\u001b[0;31m         \u001b[0mdeployer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdeploy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpod_spec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    107\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    108\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mdeploy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpod_spec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/git_kubeflow-fairing/fairing/deployers/serving/serving.py\u001b[0m in \u001b[0;36mdeploy\u001b[0;34m(self, pod_spec)\u001b[0m\n\u001b[1;32m     48\u001b[0m         url = self.backend.get_service_external_endpoint(self.service.metadata.name,\n\u001b[1;32m     49\u001b[0m                                                          \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mservice\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmetadata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnamespace\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 50\u001b[0;31m                                                          self.service.metadata.labels)\n\u001b[0m\u001b[1;32m     51\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0murl\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     52\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/git_kubeflow-fairing/fairing/kubernetes/manager.py\u001b[0m in \u001b[0;36mget_service_external_endpoint\u001b[0;34m(self, name, namespace, selectors)\u001b[0m\n\u001b[1;32m     70\u001b[0m             for event in w.stream(v1.list_namespaced_service,\n\u001b[1;32m     71\u001b[0m                                   \u001b[0mnamespace\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mnamespace\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 72\u001b[0;31m                                   label_selector=label_selector_str):\n\u001b[0m\u001b[1;32m     73\u001b[0m                 \u001b[0msvc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mevent\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'object'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     74\u001b[0m                 logger.debug(\"Event: %s %s\",\n",
+      "\u001b[0;32m/opt/conda/lib/python3.6/site-packages/kubernetes/watch/watch.py\u001b[0m in \u001b[0;36mstream\u001b[0;34m(self, func, *args, **kwargs)\u001b[0m\n\u001b[1;32m    132\u001b[0m             \u001b[0mresp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    133\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 134\u001b[0;31m                 \u001b[0;32mfor\u001b[0m \u001b[0mline\u001b[0m \u001b[0;32min\u001b[0m \u001b[0miter_resp_lines\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    135\u001b[0m                     \u001b[0;32myield\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munmarshal_event\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreturn_type\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    136\u001b[0m                     \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_stop\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/conda/lib/python3.6/site-packages/kubernetes/watch/watch.py\u001b[0m in \u001b[0;36miter_resp_lines\u001b[0;34m(resp)\u001b[0m\n\u001b[1;32m     45\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0miter_resp_lines\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     46\u001b[0m     \u001b[0mprev\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 47\u001b[0;31m     \u001b[0;32mfor\u001b[0m \u001b[0mseg\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mresp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_chunked\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdecode_content\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     48\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mseg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     49\u001b[0m             \u001b[0mseg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mseg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'utf8'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/conda/lib/python3.6/site-packages/urllib3/response.py\u001b[0m in \u001b[0;36mread_chunked\u001b[0;34m(self, amt, decode_content)\u001b[0m\n\u001b[1;32m    664\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    665\u001b[0m             \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 666\u001b[0;31m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_update_chunk_length\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    667\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchunk_left\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    668\u001b[0m                     \u001b[0;32mbreak\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/conda/lib/python3.6/site-packages/urllib3/response.py\u001b[0m in \u001b[0;36m_update_chunk_length\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    596\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchunk_left\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    597\u001b[0m             \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 598\u001b[0;31m         \u001b[0mline\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_fp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreadline\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    599\u001b[0m         \u001b[0mline\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mline\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msplit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mb';'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    600\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/conda/lib/python3.6/socket.py\u001b[0m in \u001b[0;36mreadinto\u001b[0;34m(self, b)\u001b[0m\n\u001b[1;32m    584\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    585\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 586\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sock\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecv_into\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mb\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    587\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    588\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_timeout_occurred\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/conda/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py\u001b[0m in \u001b[0;36mrecv_into\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    292\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mrecv_into\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    293\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 294\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconnection\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecv_into\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    295\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mOpenSSL\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSSL\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSysCallError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    296\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msuppress_ragged_eofs\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0margs\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Unexpected EOF'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/conda/lib/python3.6/site-packages/OpenSSL/SSL.py\u001b[0m in \u001b[0;36mrecv_into\u001b[0;34m(self, buffer, nbytes, flags)\u001b[0m\n\u001b[1;32m   1819\u001b[0m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_lib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSSL_peek\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_ssl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1820\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1821\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_lib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSSL_read\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_ssl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1822\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_raise_ssl_error\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_ssl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1823\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "import deploy_with_fairing\n",
+    "importlib.reload(deploy_with_fairing)\n",
+    "deploy_with_fairing.deploy(DOCKER_REGISTRY, BASE_IMAGE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Call the prediction endpoint\n",
+    "\n",
+    "Create a test dataset, then call the endpoint on Kubeflow for predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import requests\n",
+    "def predict(url, data, feature_names=None):\n",
+    "        pdata={\n",
+    "            \"data\": {\n",
+    "                \"names\":feature_names,\n",
+    "                \"tensor\": {\n",
+    "                    \"shape\": np.asarray(data.shape).tolist(),\n",
+    "                    \"values\": data.flatten().tolist(),\n",
+    "                },\n",
+    "            }\n",
+    "        }\n",
+    "        serialized_data = json.dumps(pdata)\n",
+    "        r = requests.post(url, data={'json':serialized_data})\n",
+    "        return r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(b'{\"data\":{\"names\":[\"t:0\",\"t:1\",\"t:2\"],\"tensor\":{\"shape\":[1,3],\"values\":[0.948'\n",
+      " b'5112428665161,0.04742114990949631,0.004067644942551851]}},\"meta\":{}}\\n')\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TODO(jlewi): How can we get the service name automatically?\n",
+    "import numpy as np\n",
+    "import pprint\n",
+    "url = \"http://fairing-service-hg7gx.kubeflow.svc.cluster.local:5000/predict\"\n",
+    "body = \"The cluster app is completely broken. Please fix it immediately.\"\n",
+    "title = \"The cluster app is not working; please fix\"  \n",
+    "r = predict(url, np.array([title, body]))\n",
+    "pprint.pprint(r.content)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -2,7 +2,7 @@ import os
 import logging
 from collections import defaultdict
 import hmac
-from flask import (abort, Flask, session, render_template, 
+from flask import (abort, Flask, session, render_template,
                    session, redirect, url_for, request,
                    flash, jsonify)
 from flask_session import Session
@@ -32,40 +32,45 @@ db.init_app(app)
 
 # Additional Setup inspired by https://github.com/bradshjg/flask-githubapp/blob/master/flask_githubapp/core.py
 app.webhook_secret = os.getenv('WEBHOOK_SECRET')
-LOG = logging.getLogger(__name__)    
+LOG = logging.getLogger(__name__)
 
 # set the prediction threshold for everything except for the label question which has a different threshold
 prediction_threshold = defaultdict(lambda: .55)
 prediction_threshold['question'] = .65
 
-
-def init():
+def init_issue_labeler():
     "Load all necessary artifacts to make predictions."
     title_pp_url = "https://storage.googleapis.com/codenet/issue_labels/issue_label_model_files/title_pp.dpkl"
     body_pp_url = 'https://storage.googleapis.com/codenet/issue_labels/issue_label_model_files/body_pp.dpkl'
     model_url = 'https://storage.googleapis.com/codenet/issue_labels/issue_label_model_files/Issue_Label_v1_best_model.hdf5'
     model_filename = 'downloaded_model.hdf5'
 
-    #save keyfile
-    pem_string = os.getenv('PRIVATE_KEY')
-    if not pem_string:
-        raise ValueError('Environment variable PRIVATE_KEY was not supplied.')
-    
-    with open('private-key.pem', 'wb') as f:
-        f.write(str.encode(pem_string))
 
     with urlopen(title_pp_url) as f:
         title_pp = dpickle.load(f)
 
     with urlopen(body_pp_url) as f:
         body_pp = dpickle.load(f)
-    
+
     model_path = get_file(fname=model_filename, origin=model_url)
     model = load_model(model_path)
+
+    return IssueLabeler(body_text_preprocessor=body_pp,
+                        title_text_preprocessor=title_pp,
+                        model=model)
+
+def init():
+    "Load all necessary artifacts to make predictions."
+    #save keyfile
+    pem_string = os.getenv('PRIVATE_KEY')
+    if not pem_string:
+        raise ValueError('Environment variable PRIVATE_KEY was not supplied.')
+
+    with open('private-key.pem', 'wb') as f:
+        f.write(str.encode(pem_string))
+
     app.graph = tf.get_default_graph()
-    app.issue_labeler = IssueLabeler(body_text_preprocessor=body_pp,
-                                     title_text_preprocessor=title_pp,
-                                     model=model)
+    app.issue_labeler = init_issue_labeler()
 
 # smee by default sends things to /event_handler route
 @app.route("/", methods=["GET"])
@@ -75,9 +80,9 @@ def index():
     num_users = f'{len(db.engine.execute("SELECT distinct username FROM issues").fetchall()):,}'
     num_predictions = f'{db.engine.execute("SELECT count(*) FROM predictions").fetchall()[0][0]:,}'
     num_repos = f'{len(results):,}'
-    return render_template("index.html", 
-                           results=results, 
-                           num_users=num_users, 
+    return render_template("index.html",
+                           results=results,
+                           num_users=num_users,
                            num_repos=num_repos,
                            num_predictions=num_predictions)
 
@@ -108,10 +113,10 @@ def bot():
                               issue_num=issue_num,
                               title=title,
                               body=body)
-        
+
         db.session.add(issue_db_obj)
         db.session.commit()
-        
+
         # make predictions with the model
         with app.graph.as_default():
             predictions = app.issue_labeler.get_probabilities(body=body, title=title)
@@ -165,7 +170,7 @@ def data(owner, repo):
 
     num_issues = len(issues)
     num_predictions = len(predictions)
-    
+
     return render_template("data.html",
                            results=predictions,
                            num_issues=num_issues,
@@ -192,8 +197,8 @@ def update_feedback(owner, repo):
 
     # grab all the reactions and update the statistics in the database.
     for prediction in predictions:
-        reactions = ghapp.get_reactions(owner=owner, 
-                                        repo=repo, 
+        reactions = ghapp.get_reactions(owner=owner,
+                                        repo=repo,
                                         comment_id=prediction.comment_id,
                                         iat=installation_access_token)
         prediction.likes = reactions['+1']

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ murmurhash==1.0.2
 nbconvert==5.4.1
 nbformat==4.4.0
 networkx==2.2
-notebook==5.7.7
+notebook==5.7.8
 numpy==1.16.2
 pandas==0.24.2
 pandocfilters==1.4.2


### PR DESCRIPTION

* Create a Makefile to build the docker image used for the flask app.

  * This is used as the base image for fairing's append builder.

* Create deploy_with_fairing.py to build the docker image using the
  append builder.

  * We need to do some gymnastics to reorganize the files in a temporary directory
  so we have the structure we need.

  * Create a separate main file for firing off the build form the Seldon
  interface; this way our model server won't try to import fairing or
  other libraries not needed during serving.

  * Define LabelIssuePrediction.py as the Seldon interface class.

* Create a notebook that can build the image using the fairing append builder
  and deploy it and then send predictions.