### PR TITLE
Setup predict.mlbot.net

### DIFF
--- a/deployment/certificate.mlbot-net.yaml
+++ b/deployment/certificate.mlbot-net.yaml
@@ -1,19 +1,19 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: predict-mlapp-tls
+  name: mlbot-net
   namespace: mlapp
 spec:
   acme:
     config:
     - domains:
-      - predict.mlbot.net
+      - mlbot.net
       http01:
-        ingress: ml-gh-app
-  commonName: predict.mlbot.net
+        ingress: mlbot-net
+  commonName: mlbot.net
   dnsNames:
-  - predict.mlbot.net
+  - mlbot.net
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod
-  secretName: predict-mlapp-tls
+  secretName: mlapp-tls

--- a/deployment/certificate.yaml
+++ b/deployment/certificate.yaml
@@ -1,0 +1,20 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: predict-mlapp-tls
+  namespace: mlapp
+  resourceVersion: "2437282"
+spec:
+  acme:
+    config:
+    - domains:
+      - predict.mlbot.net
+      http01:
+        ingress: ml-gh-app
+  commonName: predict.mlbot.net
+  dnsNames:
+  - predict.mlbot.net
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  secretName: predict-mlapp-tls

--- a/deployment/ingress.mlbot-net.yaml
+++ b/deployment/ingress.mlbot-net.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: mlbot-net
+  namespace: mlapp
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: mlbot-net
+spec:
+  backend:
+    serviceName: ml-github-app
+    servicePort: 3000
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ml-github-app
+          servicePort: 3000
+  tls:
+    - hosts:
+      - mlbot.net
+      secretName: mlapp-tls

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: ml-gh-app
   namespace: mlapp
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: mlbot
 spec:
   backend:
     serviceName: ml-github-app
@@ -14,3 +16,7 @@ spec:
         backend:
           serviceName: ml-github-app
           servicePort: 3000
+  tls:
+    - hosts:
+      - predict.mlbot.net
+      secretName: predict-mlapp-tls


### PR DESCRIPTION
* Use a static IP so the IP won't change each time we redeploy
* Use certificate manager to provision certificate; we can't use GKE
  managed certificates because it requires 1.12

* Certificate manager is already deployed as part of Kubeflow.